### PR TITLE
Prevent to touch items by another user

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -91,7 +91,7 @@ class ItemsController < ApplicationController
   private
 
   def set_item
-    @item = Item.find(params[:id])
+    @item = current_user.items.find(params[:id])
   end
 
   def item_params


### PR DESCRIPTION
セキュリティ issue ですが、 

>こちらはポートフォリオサービスです。
実際に運用されてはいませんのでご了承ください。

とのことなので public に報告致します。

<img width="690" alt="スクリーンショット 2021-02-14 23 51 21" src="https://user-images.githubusercontent.com/1180335/107880253-0bf2d680-6f21-11eb-9fb1-b5f7573b7ff0.png">

https://github.com/Y-h-tomo/jimoshare-app/blob/66e513e0e6315e91251636f91ee498acc90f91e7/app/views/items/_show_item.html.slim#L79-L91

この様に、特定条件下でないとitemの編集や削除の導線を出さなくしていると思うのですが

<img width="1184" alt="スクリーンショット 2021-02-14 23 52 07" src="https://user-images.githubusercontent.com/1180335/107880258-10b78a80-6f21-11eb-9617-9af3a70f1e4d.png">

https://jimoshare.tk/items/6/edit の様なURLに直接アクセスすることで、編集が可能です。また、一度編集すると投稿者が編集者に変わってしまいました。

<img width="608" alt="スクリーンショット 2021-02-14 23 52 18" src="https://user-images.githubusercontent.com/1180335/107880262-1319e480-6f21-11eb-9f5b-8ebfe5d53b06.png">

削除に関しても、 curl 等を使って 削除エンドポイントを叩くことで他人の投稿したitemでさえも削除することが出来ました。

<img width="631" alt="スクリーンショット 2021-02-14 23 58 32" src="https://user-images.githubusercontent.com/1180335/107880263-13b27b00-6f21-11eb-9a6c-eae7ae53685b.png">
<img width="1175" alt="スクリーンショット 2021-02-14 23 58 54" src="https://user-images.githubusercontent.com/1180335/107880264-144b1180-6f21-11eb-8701-3878e13e82a9.png">

これらの挙動はおそらく意図したものではないと思うので、修正PRを送ります。
動作確認は取れていないのですが、

https://github.com/Y-h-tomo/jimoshare-app/blob/cd6faa56c36d135012c785cddf86698c0e88dfda/app/models/user.rb#L8

から、おそらくこれで動くのでは？と思っています。
